### PR TITLE
Top Sellers data fetched and displayed + skeleton loading state

### DIFF
--- a/src/components/home/TopSellers.jsx
+++ b/src/components/home/TopSellers.jsx
@@ -1,8 +1,26 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
+import axios from "axios";
 import { Link } from "react-router-dom";
-import AuthorImage from "../../images/author_thumbnail.jpg";
+import Skeleton from "../UI/Skeleton";
 
 const TopSellers = () => {
+  const [nftArray, setNftArray] = useState([]);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const response = await axios.get(
+          "https://us-central1-nft-cloud-functions.cloudfunctions.net/topSellers"
+        );
+        setNftArray(response.data);
+      } catch (error) {
+        console.error("Error fetching data:", error);
+      }
+    };
+
+    fetchData();
+  }, []);
+
   return (
     <section id="section-popular" className="pb-5">
       <div className="container">
@@ -15,24 +33,42 @@ const TopSellers = () => {
           </div>
           <div className="col-md-12">
             <ol className="author_list">
-              {new Array(12).fill(0).map((_, index) => (
-                <li key={index}>
-                  <div className="author_list_pp">
-                    <Link to="/author">
-                      <img
-                        className="lazy pp-author"
-                        src={AuthorImage}
-                        alt=""
-                      />
-                      <i className="fa fa-check"></i>
-                    </Link>
-                  </div>
-                  <div className="author_list_info">
-                    <Link to="/author">Monica Lucas</Link>
-                    <span>2.1 ETH</span>
-                  </div>
-                </li>
-              ))}
+              {nftArray.length > 0
+                ? nftArray.map((nft) => (
+                    <li key={nft?.id}>
+                      <div className="author_list_pp">
+                        <Link to="/author">
+                          <img
+                            className="lazy pp-author"
+                            src={nft?.authorImage}
+                            alt=""
+                          />
+                          <i className="fa fa-check"></i>
+                        </Link>
+                      </div>
+                      <div className="author_list_info">
+                        <Link to="/author">{nft?.authorName}</Link>
+                        <span>{`${nft?.price} ETH`}</span>
+                      </div>
+                    </li>
+                  ))
+                : Array.from({ length: 12 }).map((_, index) => (
+                    <li key={index}>
+                      <div className="author_list_pp">
+                        <Skeleton
+                          height={"50px"}
+                          width={"50px"}
+                          borderRadius={"25px"}
+                        />
+                      </div>
+                      <div className="author_list_info">
+                        <Skeleton height={"18px"} width={"100px"} />
+                        <span>
+                          <Skeleton height={"16px"} width={"40px"} />
+                        </span>
+                      </div>
+                    </li>
+                  ))}
             </ol>
           </div>
         </div>


### PR DESCRIPTION
Task :
Fetch the top sellers data from the given website and replace the repeated 12 top sellers. Include a skeleton state animation that is only active when the data is not fetched.

Why :
Seeing repeated top sellers defeats the whole purpose of the website which is to sell NFTs to the user. Him seeing something repetitive will give the impression that there's no variety. For the skeleton state animation, its goal is to give the user the effect that data is loading. It makes the website appear faster. Also, for people who have slow connection, the skeleton loading state ensures that they don't look at a blank page while data is being fetched.

How :
For the data fetching, I used a useState to create an nft array and a setter to the array. Then I used a useEffect that runs on website mount. In the useEffect, there's an axios function that fetches the data and then sets the nft array to that data. I then mapped over the nft array to create 12 top sellers. Finally, for the skeleton state, I used a conditional statement. When nftArray.length is bigger than 0, I show the nftArray.map(), and when it isn't bigger than 0, I show an array of length 12 that has 12 top sellers with the author image, name and price all having a skeleton state animation.

SCREENSHOTS

![top sellers before changes](https://github.com/AnmaritoS/anmar-internship/assets/95002766/60048f72-6595-41ce-b214-745b492d3575)

![top sellers after changes 1](https://github.com/AnmaritoS/anmar-internship/assets/95002766/e310be81-e9db-4f18-8a23-f31372ebe884)

![top sellers after changes 2](https://github.com/AnmaritoS/anmar-internship/assets/95002766/875f690f-73f5-4f3b-bb4a-2ecdf3ff95c1)
